### PR TITLE
Add async burst runner and NovaSanctum codex

### DIFF
--- a/configs/mkww-repos.ts
+++ b/configs/mkww-repos.ts
@@ -1,0 +1,9 @@
+export default [
+  'MKWorldWide/NovaSanctum',
+  'MKWorldWide/AthenaMyst_Host',
+  'MKWorldWide/Aletheia',
+  'MKWorldWide/CursorKitt3n',
+  'MKWorldWide/GameDin',
+  'MKWorldWide/BioSynth',
+  'MKWorldWide/Primal-Genesis-Engine-Sovereign',
+];

--- a/configs/presets/nova-sanctum-preset.ts
+++ b/configs/presets/nova-sanctum-preset.ts
@@ -1,0 +1,14 @@
+export default {
+  folders: ['src', 'plugins', 'routes', 'lib', 'types'],
+  files: [
+    'README.md',
+    '.gitignore',
+    'package.json',
+    'codex.config.ts',
+    'routes/index.ts',
+    'plugins/loader.ts',
+    '.env.example',
+    'ci.yml',
+  ],
+  notes: 'Routing and Plugin Injection System enabled. Connects to CursorKitten + AthenaDaemon.',
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:coverage": "jest --coverage",
     "prepare": "husky install",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "burst:all-dev": "node scripts/burst-async-dev.ts"
   },
   "dependencies": {
     "@aws-amplify/ui-react": "^5.0.0",

--- a/scripts/burst-async-dev.ts
+++ b/scripts/burst-async-dev.ts
@@ -1,0 +1,45 @@
+import { codex } from 'cursor-sdk';
+import repos from '../configs/mkww-repos';
+
+async function createDevEnv(repo: string) {
+  try {
+    await codex.environments.create({
+      repo,
+      name: 'dev',
+      description: `Auto-generated dev environment for ${repo}`,
+      tasks: [
+        {
+          title: 'Initialize dev branch',
+          prompt: `Scaffold a development-ready branch for ${repo}. Include proper README.md, .gitignore, package.json if needed, and default src folder structure.`,
+        },
+      ],
+    });
+    console.log(`✅ [${repo}] Dev environment created.`);
+    return { repo, status: 'success' };
+  } catch (err: any) {
+    console.error(`❌ [${repo}] Error:`, err.message);
+    return { repo, status: 'fail', error: err.message };
+  }
+}
+
+export async function burstAll() {
+  console.log('🚀 CursorKitten Async Burst Started');
+
+  const results = await Promise.allSettled(repos.map(repo => createDevEnv(repo)));
+
+  const summary = {
+    success: results
+      .filter(r => r.status === 'fulfilled' && (r as any).value.status === 'success')
+      .map((r: any) => r.value.repo),
+    failed: results
+      .filter(r => r.status === 'fulfilled' && (r as any).value.status === 'fail')
+      .map((r: any) => r.value.repo),
+    errors: results.filter(r => r.status === 'rejected').map(r => (r as any).reason),
+  };
+
+  console.log('✨ Burst Summary:', summary);
+}
+
+if (require.main === module) {
+  burstAll();
+}

--- a/src/codex/agents/CursorKitten.ts
+++ b/src/codex/agents/CursorKitten.ts
@@ -1,0 +1,8 @@
+export const CursorKitten = {
+  name: 'CursorKitten',
+  env: 'dev',
+  execute: async () => {
+    // This could be a Codex API call, or file transformation.
+    return 'CursorKitten upgraded NovaSanctum repo 💾';
+  },
+};

--- a/src/codex/codex.registry.ts
+++ b/src/codex/codex.registry.ts
@@ -1,0 +1,136 @@
+export const repoRegistry = [
+  { name: 'MKWW', path: '../MKWW', env: 'EsKaye/MKWW', agent: 'Athena' },
+  { name: 'Aeternum', path: '../Aeternum', env: 'MKWorldWide/Aeternum', agent: 'Aletheia' },
+  { name: 'Aincrad', path: '../Aincrad', env: 'MKWorldWide/Aincrad', agent: 'Athena' },
+  { name: 'Aletheia', path: '../Aletheia', env: 'MKWorldWide/Aletheia', agent: 'Aletheia' },
+  {
+    name: 'AthenaMyst_Host',
+    path: '../AthenaMyst_Host',
+    env: 'MKWorldWide/AthenaMyst_Host',
+    agent: 'Athena',
+  },
+  {
+    name: 'AthenaMyst_Test',
+    path: '../AthenaMyst_Test',
+    env: 'MKWorldWide/AthenaMyst_Test',
+    agent: 'Athena',
+  },
+  { name: 'BioSynth', path: '../BioSynth', env: 'MKWorldWide/BioSynth', agent: 'Eidolon' },
+  { name: 'Bl3nder', path: '../Bl3nder', env: 'MKWorldWide/Bl3nder', agent: 'CursorKitten' },
+  { name: 'Cathedral', path: '../Cathedral', env: 'MKWorldWide/Cathedral', agent: 'Seraphina' },
+  { name: 'Celesstial', path: '../Celesstial', env: 'MKWorldWide/Celesstial', agent: 'Athena' },
+  {
+    name: 'CursorKitt3n',
+    path: '../CursorKitt3n',
+    env: 'MKWorldWide/CursorKitt3n',
+    agent: 'CursorKitten',
+  },
+  { name: 'Divina-L3', path: '../Divina-L3', env: 'MKWorldWide/Divina-L3', agent: 'Aletheia' },
+  { name: 'EdenOneCity', path: '../EdenOneCity', env: 'MKWorldWide/EdenOneCity', agent: 'Athena' },
+  { name: 'GameDin', path: '../GameDin', env: 'MKWorldWide/GameDin', agent: 'CursorKitten' },
+  {
+    name: 'GameDinDiscord',
+    path: '../GameDinDiscord',
+    env: 'MKWorldWide/GameDinDiscord',
+    agent: 'Seraphina',
+  },
+  { name: 'GameDinM', path: '../GameDinM', env: 'MKWorldWide/GameDinM', agent: 'Athena' },
+  { name: 'GameDinVR', path: '../GameDinVR', env: 'MKWorldWide/GameDinVR', agent: 'Athena' },
+  {
+    name: 'Genesis-Drive',
+    path: '../Genesis-Drive',
+    env: 'MKWorldWide/Genesis-Drive',
+    agent: 'Sovereign',
+  },
+  { name: 'GLASSPHERE', path: '../GLASSPHERE', env: 'MKWorldWide/GLASSPHERE', agent: 'Aletheia' },
+  { name: 'Home', path: '../Home', env: 'MKWorldWide/Home', agent: 'Athena' },
+  { name: 'Lilith.Eve', path: '../Lilith.Eve', env: 'MKWorldWide/Lilith.Eve', agent: 'Athena' },
+  { name: 'LilithOS', path: '../LilithOS', env: 'MKWorldWide/LilithOS', agent: 'Athena' },
+  { name: 'LilithOSi', path: '../LilithOSi', env: 'MKWorldWide/LilithOSi', agent: 'Athena' },
+  { name: 'Lilybear', path: '../Lilybear', env: 'MKWorldWide/Lilybear', agent: 'CursorKitten' },
+  { name: 'LuxCore', path: '../LuxCore', env: 'MKWorldWide/LuxCore', agent: 'Aletheia' },
+  {
+    name: 'MatrixOS-Layer0',
+    path: '../MatrixOS-Layer0',
+    env: 'MKWorldWide/MatrixOS-Layer0',
+    agent: 'Athena',
+  },
+  {
+    name: 'MKronoSphere',
+    path: '../MKronoSphere',
+    env: 'MKWorldWide/MKronoSphere',
+    agent: 'Athena',
+  },
+  { name: 'MKZenith', path: '../MKZenith', env: 'MKWorldWide/MKZenith', agent: 'Athena' },
+  {
+    name: 'NovaSanctum',
+    path: '../NovaSanctum',
+    env: 'MKWorldWide/NovaSanctum',
+    agent: 'CursorKitten',
+  },
+  { name: 'NovaTiny', path: '../NovaTiny', env: 'MKWorldWide/NovaTiny', agent: 'CursorKitten' },
+  {
+    name: 'Primal-Genesis-Engine-Sovereign',
+    path: '../Primal-Genesis-Engine-Sovereign',
+    env: 'MKWorldWide/Primal-Genesis-Engine-Sovereign',
+    agent: 'Sovereign',
+  },
+  {
+    name: 'primal-genesis-manifest',
+    path: '../primal-genesis-manifest',
+    env: 'MKWorldWide/primal-genesis-manifest',
+    agent: 'Sovereign',
+  },
+  {
+    name: 'Project-LOWKEY',
+    path: '../Project-LOWKEY',
+    env: 'MKWorldWide/Project-LOWKEY',
+    agent: 'Athena',
+  },
+  {
+    name: 'PuppyThoth',
+    path: '../PuppyThoth',
+    env: 'MKWorldWide/PuppyThoth',
+    agent: 'CursorKitten',
+  },
+  {
+    name: 'RezzonanceTouch',
+    path: '../RezzonanceTouch',
+    env: 'MKWorldWide/RezzonanceTouch',
+    agent: 'Aletheia',
+  },
+  { name: 'S.O.S.', path: '../S.O.S.', env: 'MKWorldWide/S.O.S.', agent: 'Athena' },
+  { name: 'Scrypt', path: '../Scrypt', env: 'MKWorldWide/Scrypt', agent: 'Athena' },
+  {
+    name: 'Shadow-Nexus',
+    path: '../Shadow-Nexus',
+    env: 'MKWorldWide/Shadow-Nexus',
+    agent: 'Athena',
+  },
+  { name: 'SKyCitadel', path: '../SKyCitadel', env: 'MKWorldWide/SKyCitadel', agent: 'Athena' },
+  {
+    name: 'SolAscension',
+    path: '../SolAscension',
+    env: 'MKWorldWide/SolAscension',
+    agent: 'Athena',
+  },
+  { name: 'SoulScript', path: '../SoulScript', env: 'MKWorldWide/SoulScript', agent: 'Athena' },
+  {
+    name: 'WhispurrNet',
+    path: '../WhispurrNet',
+    env: 'MKWorldWide/WhispurrNet',
+    agent: 'CursorKitten',
+  },
+];
+
+import { CursorKitten } from './agents/CursorKitten';
+// import { Athena } from './agents/Athena';
+// import { Aletheia } from './agents/Aletheia';
+// import { EidolonCore } from './agents/EidolonCore';
+
+export const agents = {
+  CursorKitten,
+  // Athena,
+  // Aletheia,
+  // EidolonCore,
+};

--- a/src/codex/codexBurst.ts
+++ b/src/codex/codexBurst.ts
@@ -1,0 +1,16 @@
+import { agents } from './codex.registry';
+
+export async function codexBurst(env: 'dev' | 'prod' = 'dev') {
+  const selectedAgents = Object.values(agents).filter(agent => agent.env === env);
+
+  for (const agent of selectedAgents) {
+    console.log(`[💥 CodexBurst] Firing ${agent.name}...`);
+
+    try {
+      const result = await agent.execute();
+      console.log(`[✅ ${agent.name}]`, result);
+    } catch (err) {
+      console.error(`[❌ ${agent.name}] Error`, err);
+    }
+  }
+}

--- a/src/codex/nova-sanctum.ts
+++ b/src/codex/nova-sanctum.ts
@@ -1,0 +1,38 @@
+import { defineCodex } from 'cursor-sdk';
+
+export default defineCodex({
+  name: 'NovaSanctum',
+  description:
+    'NovaSanctum Codex: Codex of Codex Agents, Plugin Loaders, and Environment Blueprints.',
+  agents: [
+    {
+      id: 'NovaSanctum/CursorKitten',
+      persona:
+        'A cunning, playful multi-threaded dev burst agent. Specializes in async repo environments, logging, and recovery. Handles global dev bootstraps.',
+    },
+    {
+      id: 'NovaSanctum/AthenaDaemon',
+      persona:
+        'Oversees health and lifecycle of Codex environments. Handles watchdog recovery, error summaries, and deferred rebuilds.',
+    },
+    {
+      id: 'NovaSanctum/Aletheia',
+      persona:
+        'Vision-based input interpreter. Accepts abstract, poetic, or symbolic input and translates into Codex tasks or prompts.',
+    },
+    {
+      id: 'NovaSanctum/SanctumScaffold',
+      persona:
+        'Scaffold generator that tailors NovaSanctum-specific routing, plugin injection, and CI/CD presets. Auto-attaches `nova-sanctum-preset.ts` if repo ID matches.',
+    },
+  ],
+  environments: {
+    sharedPreset: 'nova-sanctum-preset.ts',
+    triggers: [
+      {
+        condition: (repo: string) => repo.includes('NovaSanctum'),
+        action: 'Inject routing + CI/CD into dev scaffold',
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- add async burst script with dev environment logic
- provide repo list and nova-sanctum preset configs
- define NovaSanctum codex file for agent details
- expose `burst:all-dev` npm script

## Testing
- `npx prettier -w src/codex scripts configs package.json`
- `npm test` *(fails: Test Suites: 1 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687741f619e48325aa105d8b67831d0b